### PR TITLE
Add support for building the wallet without GUI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+group: travis_latest
 
 services:
     - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ services:
     - docker
 
 before_install:
-    - docker pull alediaferia/electra
+    - docker pull electracoin/electra
 
 script:
-    - docker run alediaferia/electra /bin/bash -c "su - ecadev; git clone -b $TRAVIS_BRANCH --single-branch https://github.com/Electra-project/Electra.git; cd Electra; qmake; make"
+    - docker run electracoin/electra /bin/bash -c "su - ecadev; git clone -b $TRAVIS_BRANCH --single-branch https://github.com/Electra-project/Electra.git; cd Electra; qmake; make"
+    - docker run electracoin/electra /bin/bash -c "su - ecadev; git clone -b $TRAVIS_BRANCH --single-branch https://github.com/Electra-project/Electra.git; cd Electra; qmake GUI=0; make"

--- a/src/gui.pro
+++ b/src/gui.pro
@@ -3,7 +3,7 @@ TARGET = Electra-qt
 macx:TARGET = "Electra-qt"
 VERSION = 1.2.0
 INCLUDEPATH += json qt $$PWD
-DEFINES += QT_GUI BOOST_THREAD_USE_LIB BOOST_SPIRIT_THREADSAFE HAVE_CXX_STDHEADERS MINIUPNP_STATICLIB
+DEFINES += BOOST_THREAD_USE_LIB BOOST_SPIRIT_THREADSAFE HAVE_CXX_STDHEADERS MINIUPNP_STATICLIB
 CONFIG += thread
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 lessThan(QT_MAJOR_VERSION, 5): CONFIG += static
@@ -27,6 +27,17 @@ win32 {
     QRENCODE_INCLUDE_PATH=C:/deps/qrencode-3.4.4
     QRENCODE_LIB_PATH=C:/deps/qrencode-3.4.4/.libs
 }
+
+# GUI enabled by default
+# use: qmake "GUI=0" to disable it
+contains(GUI, 0) {
+    message(Building without GUI support)
+    QT -= gui # Only the core module is used.
+} else {
+    message(Building with GUI support)
+    DEFINES += QT_GUI
+}
+
 
 LIBS += -L$$PWD -lcore
 

--- a/src/qt/Electra.cpp
+++ b/src/qt/Electra.cpp
@@ -110,7 +110,7 @@ static void handleRunawayException(std::exception *e)
     exit(1);
 }
 
-#ifndef ELECTRA_QT_TEST
+#if !defined(ELECTRA_QT_TEST) && defined(QT_GUI)
 int main(int argc, char *argv[])
 {
     // Do this early as we don't want to bother initializing if we are just calling IPC


### PR DESCRIPTION
Thanks to @AlejandroVera for this patch.

Use qmake GUI=0 to disable the compilation of the GUI part